### PR TITLE
use le-challenge-sni for tls-sni-01 challenges

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ LE.create = function (le) {
     le.challenges['http-01'] = require('le-challenge-fs').create({ debug: le.debug });
   }
   if (!le.challenges['tls-sni-01']) {
-    le.challenges['tls-sni-01'] = le.challenges['http-01'];
+    le.challenges['tls-sni-01'] = require('le-challenge-sni').create({ debug: le.debug });
   }
   if (!le.challenges['dns-01']) {
     try {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "url": "https://github.com/Daplie/node-letsencrypt/issues"
   },
   "homepage": "https://github.com/Daplie/node-letsencrypt#readme",
-  "devDependencies": {},
+  "devDependencies": {
+    "request": "^2.75.0"
+  },
   "optionalDependencies": {},
   "dependencies": {
     "asn1js": "^1.2.12",
@@ -38,6 +40,7 @@
     "homedir": "^0.6.0",
     "le-acme-core": "^2.0.5",
     "le-challenge-fs": "^2.0.2",
+    "le-challenge-sni": "^2.0.0",
     "le-sni-auto": "^2.0.1",
     "le-store-certbot": "^2.0.3",
     "localhost.daplie.com-certificates": "^1.2.3",


### PR DESCRIPTION
This is a small update that simply uses my module `le-challenge-sni` for tls-sni-01 challenges as a default for convenience. Previously, http-01 challenges were simply served on port 443, which as a general rule wouldn't work.

See also https://github.com/Daplie/le-sni-auto/pull/2
